### PR TITLE
Return the core library to .Net Standard 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NuGet Status](http://img.shields.io/nuget/v/mapbox-vector-tile.svg?style=flat)](https://www.nuget.org/packages/mapbox-vector-tile/) ![.NET 8](https://github.com/bertt/mapbox-vector-tile-cs/workflows/.NET%208/badge.svg)
 
-.NET 8 library for decoding a Mapbox vector tile. 
+.NET Standard 2.0 library for decoding a Mapbox vector tile. 
 
 ## Dependencies
 

--- a/src/mapbox.vector.tile.csproj
+++ b/src/mapbox.vector.tile.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+	<LangVersion>12</LangVersion>
     <Version>5.1.0</Version>
 	<AssemblyVersion>5.1.0.0</AssemblyVersion>
 	<FileVersion>5.1.0.0</FileVersion>


### PR DESCRIPTION
The solution has over time been moved from .Net Standard to various versions of .Net. Presumably some dependencies of the samples, tests, and benchmark projects required this.

However, it was not necessary to change the framework of the core `mapbox.vector.tile` library. It can still quite happily target .Net Standard 2.0, for maximum compatibility.

I have set the `LangVersion` property to allow .Net 8 language syntax to be used within the project.