### PR TITLE
Reduced heap allocations during geometry parsing

### DIFF
--- a/src/ClassifyRings.cs
+++ b/src/ClassifyRings.cs
@@ -5,17 +5,17 @@ namespace Mapbox.Vector.Tile;
 public class ClassifyRings
 {
     // docs for inner/outer rings https://www.mapbox.com/vector-tiles/specification/
-    public static List<List<List<Coordinate>>> Classify(List<List<Coordinate>> rings)
+    public static List<List<IList<Coordinate>>> Classify(IEnumerable<IList<Coordinate>> rings)
     {
-        var polygons = new List<List<List<Coordinate>>>();
-        List<List<Coordinate>> newpoly = null;
+        var polygons = new List<List<IList<Coordinate>>>();
+        List<IList<Coordinate>> newpoly = null;
         foreach (var ring in rings)
         {
             var poly = new VTPolygon(ring);
 
             if (poly.IsOuterRing())
             {
-                newpoly = new List<List<Coordinate>>() { ring };
+                newpoly = [ring];
                 polygons.Add(newpoly);
             }
             else

--- a/src/Coordinate.cs
+++ b/src/Coordinate.cs
@@ -1,7 +1,7 @@
 ﻿namespace Mapbox.Vector.Tile;
 
-public class Coordinate
+public struct Coordinate(long x, long y)
 {
-    public long X { get; set; }
-    public long Y { get; set; }
+    public long X { get; set; } = x; 
+    public long Y { get; set; } = y;
 }

--- a/src/VTPolygon.cs
+++ b/src/VTPolygon.cs
@@ -4,9 +4,9 @@ namespace Mapbox.Vector.Tile;
 
 public class VTPolygon
 {
-    private List<Coordinate> points;
+    private IList<Coordinate> points;
 
-    public VTPolygon(List<Coordinate> points)
+    public VTPolygon(IList<Coordinate> points)
     {
         this.points = points;
     }

--- a/src/VectorTileFeature.cs
+++ b/src/VectorTileFeature.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Mapbox.Vector.Tile;
 
 public class VectorTileFeature
 {
     public string Id { get; set; }
-    public List<List<Coordinate>> Geometry { get; set; }
+    public List<ArraySegment<Coordinate>> Geometry { get; set; }
     public List<KeyValuePair<string, object>> Attributes { get; set; }
     public Tile.GeomType GeometryType { get; set; }
     public uint Extent { get; set; }


### PR DESCRIPTION
- `Coordinate` is now a struct
- `GeometryParser` returns `ArraySegment<Coordinate>` instead of many individual lists
- Fixed `VectorTileFeatureExtensions.ProjectPoints` when multiple points are provided