### PR TITLE
Enable Nullable in all projects and fix build warnings

### DIFF
--- a/benchmark/mapbox.vector.tile.benchmark.csproj
+++ b/benchmark/mapbox.vector.tile.benchmark.csproj
@@ -3,6 +3,7 @@
 	  <OutputType>Exe</OutputType>
 	  <TargetFramework>net8.0</TargetFramework>
 	  <IsPackable>false</IsPackable>
+	  <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <None Update="testdata\14-8801-5371.vector.pbf">

--- a/src/AttributesParser.cs
+++ b/src/AttributesParser.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Mapbox.Vector.Tile;
@@ -23,36 +24,37 @@ public static class AttributesParser
 
     private static object GetAttr(Tile.Value value)
     {
-        object res = null;
-
         if (value.HasBoolValue)
         {
-            res = value.BoolValue;
+            return value.BoolValue;
         }
         else if (value.HasDoubleValue)
         {
-            res = value.DoubleValue;
+            return value.DoubleValue;
         }
         else if (value.HasFloatValue)
         {
-            res = value.FloatValue;
+            return value.FloatValue;
         }
         else if (value.HasIntValue)
         {
-            res = value.IntValue;
+            return value.IntValue;
         }
         else if (value.HasStringValue)
         {
-            res = value.StringValue;
+            return value.StringValue;
         }
         else if (value.HasSIntValue)
         {
-            res = value.SintValue;
+            return value.SintValue;
         }
         else if (value.HasUIntValue)
         {
-            res = value.UintValue;
+            return value.UintValue;
         }
-        return res;
+        else
+        {
+            throw new NotImplementedException("Unknown attribute type");
+        }
     }
 }

--- a/src/ClassifyRings.cs
+++ b/src/ClassifyRings.cs
@@ -8,7 +8,7 @@ public class ClassifyRings
     public static List<List<IList<Coordinate>>> Classify(IEnumerable<IList<Coordinate>> rings)
     {
         var polygons = new List<List<IList<Coordinate>>>();
-        List<IList<Coordinate>> newpoly = null;
+        List<IList<Coordinate>>? newpoly = null;
         foreach (var ring in rings)
         {
             var poly = new VTPolygon(ring);

--- a/src/FeatureParser.cs
+++ b/src/FeatureParser.cs
@@ -5,21 +5,11 @@ namespace Mapbox.Vector.Tile;
 
 public static class FeatureParser
 {
-    public static VectorTileFeature Parse(Tile.Feature feature, List<string> keys, List<Tile.Value> values, uint extent)
-    {
-        var result = new VectorTileFeature();
-        var id = feature.Id;
-
-        var geom = GeometryParser.ParseGeometry(feature.Geometry, feature.Type);
-        result.GeometryType = feature.Type;
-
-        // add the geometry
-        result.Geometry = geom;
-        result.Extent = extent;
-
-        // now add the attributes
-        result.Id = id.ToString(CultureInfo.InvariantCulture);
-        result.Attributes = AttributesParser.Parse(keys, values, feature.Tags);
-        return result;
-    }
+    public static VectorTileFeature Parse(Tile.Feature feature, List<string> keys, List<Tile.Value> values, uint extent) => new(
+        id: feature.Id.ToString(CultureInfo.InvariantCulture),
+        geometry: GeometryParser.ParseGeometry(feature.Geometry, feature.Type),
+        attributes: AttributesParser.Parse(keys, values, feature.Tags),
+        geometryType: feature.Type,
+        extent: extent
+    );
 }

--- a/src/VectorTile.cs
+++ b/src/VectorTile.cs
@@ -119,7 +119,7 @@ public sealed class Tile : ProtoBuf.IExtensible
                 HasBoolValue = true;
             }
         }
-        ProtoBuf.IExtension _extensionObject;
+        ProtoBuf.IExtension? _extensionObject;
         ProtoBuf.IExtension ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
         { return ProtoBuf.Extensible.GetExtensionObject(ref _extensionObject, createIfMissing); }
     }
@@ -157,7 +157,7 @@ public sealed class Tile : ProtoBuf.IExtensible
             get { return _geometry; }
         }
 
-        ProtoBuf.IExtension _extensionObject;
+        ProtoBuf.IExtension? _extensionObject;
         ProtoBuf.IExtension ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
         { return ProtoBuf.Extensible.GetExtensionObject(ref _extensionObject, createIfMissing); }
     }
@@ -172,9 +172,9 @@ public sealed class Tile : ProtoBuf.IExtensible
             get { return _version; }
             set { _version = value; }
         }
-        string _name;
+        string? _name;
         [ProtoBuf.ProtoMember(1, IsRequired = true, Name = @"name", DataFormat = ProtoBuf.DataFormat.Default)]
-        public string Name
+        public string? Name
         {
             get { return _name; }
             set { _name = value; }
@@ -208,7 +208,7 @@ public sealed class Tile : ProtoBuf.IExtensible
             get { return _extent; }
             set { _extent = value; }
         }
-        ProtoBuf.IExtension _extensionObject;
+        ProtoBuf.IExtension? _extensionObject;
         ProtoBuf.IExtension ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
         { return ProtoBuf.Extensible.GetExtensionObject(ref _extensionObject, createIfMissing); }
     }
@@ -230,7 +230,7 @@ public sealed class Tile : ProtoBuf.IExtensible
         Polygon = 3
     }
 
-    ProtoBuf.IExtension _extensionObject;
+    ProtoBuf.IExtension? _extensionObject;
     ProtoBuf.IExtension ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
     { return ProtoBuf.Extensible.GetExtensionObject(ref _extensionObject, createIfMissing); }
 }

--- a/src/VectorTileFeature.cs
+++ b/src/VectorTileFeature.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 
 namespace Mapbox.Vector.Tile;
 
-public class VectorTileFeature
+public class VectorTileFeature(string id, List<ArraySegment<Coordinate>> geometry, List<KeyValuePair<string, object>> attributes, Tile.GeomType geometryType, uint extent)
 {
-    public string Id { get; set; }
-    public List<ArraySegment<Coordinate>> Geometry { get; set; }
-    public List<KeyValuePair<string, object>> Attributes { get; set; }
-    public Tile.GeomType GeometryType { get; set; }
-    public uint Extent { get; set; }
+    public string Id { get; set; } = id;
+    public List<ArraySegment<Coordinate>> Geometry { get; set; } = geometry;
+    public List<KeyValuePair<string, object>> Attributes { get; set; } = attributes;
+    public Tile.GeomType GeometryType { get; set; } = geometryType;
+    public uint Extent { get; set; } = extent;
 }
 

--- a/src/VectorTileLayer.cs
+++ b/src/VectorTileLayer.cs
@@ -2,16 +2,11 @@
 
 namespace Mapbox.Vector.Tile;
 
-public class VectorTileLayer
+public class VectorTileLayer(string name, uint version, uint extent)
 {
-        public VectorTileLayer()
-        {
-            VectorTileFeatures = new List<VectorTileFeature>();
-        }
-
-	public List<VectorTileFeature> VectorTileFeatures { get;set; }
-	public string Name { get; set; }
-	public uint Version { get; set; }
-	public uint Extent { get; set; }
+    public List<VectorTileFeature> VectorTileFeatures { get; set; } = [];
+    public string Name { get; set; } = name;
+    public uint Version { get; set; } = version;
+    public uint Extent { get; set; } = extent;
 }
 

--- a/src/VectorTileParser.cs
+++ b/src/VectorTileParser.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using ProtoBuf;
+using System.Collections.Generic;
 using System.IO;
-using ProtoBuf;
 
 namespace Mapbox.Vector.Tile;
 
@@ -13,10 +13,7 @@ public static class VectorTileParser
         foreach (var layer in tile.Layers)
         {
             var extent = layer.Extent;
-            var vectorTileLayer = new VectorTileLayer();
-            vectorTileLayer.Name = layer.Name;
-            vectorTileLayer.Version = layer.Version;
-            vectorTileLayer.Extent = layer.Extent;
+            var vectorTileLayer = new VectorTileLayer(layer.Name ?? "[Unnamed]", layer.Version, extent);
 
             foreach (var feature in layer.Features)
             {

--- a/src/mapbox.vector.tile.csproj
+++ b/src/mapbox.vector.tile.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-	<LangVersion>12</LangVersion>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
     <Version>5.2.1</Version>
 	<AssemblyVersion>5.2.1.0</AssemblyVersion>
 	<FileVersion>5.2.1.0</FileVersion>

--- a/tests/AttributesParserTests.cs
+++ b/tests/AttributesParserTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+﻿using System.IO;
 using NUnit.Framework;
 using ProtoBuf;
 
@@ -10,8 +10,8 @@ public class AttributesParserTests
     public void TestAttributeParser()
     {
         // arrange
-        const string mapboxfile = "mapbox.vector.tile.tests.testdata.14-8801-5371.vector.pbf";
-        var pbfStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(mapboxfile);
+        const string mapboxfile = "14-8801-5371.vector.pbf";
+        var pbfStream = File.OpenRead(Path.Combine("testdata", mapboxfile));
         var tile = Serializer.Deserialize<Tile>(pbfStream);
         var keys = tile.Layers[0].Keys;
         var values = tile.Layers[0].Values;

--- a/tests/DeserializeSerializeBackTests.cs
+++ b/tests/DeserializeSerializeBackTests.cs
@@ -2,7 +2,6 @@
 using NUnit.Framework;
 using ProtoBuf;
 using System.IO;
-using System.Reflection;
 
 namespace mapbox.vector.tile.tests;
 
@@ -11,8 +10,8 @@ public class DeserializeSerializeBackTests
     [Test]
     public void TestIssue16()
     {
-        string pbf = "mapbox.vector.tile.tests.testdata.16_34440_23455_raw.mvt";
-        var pbfStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(pbf);
+        string pbf = "16_34440_23455_raw.mvt";
+        var pbfStream = File.OpenRead(Path.Combine("testdata", pbf));
 
         // deserialize the tile first
         var tile = Serializer.Deserialize<Tile>(pbfStream);

--- a/tests/LotsOfTagsTest.cs
+++ b/tests/LotsOfTagsTest.cs
@@ -1,5 +1,5 @@
 ﻿using NUnit.Framework;
-using System.Reflection;
+using System.IO;
 
 namespace Mapbox.Vector.Tile.tests;
 
@@ -9,8 +9,8 @@ public class LotsOfTagsTest
     public void TestLotsOfTags()
     {
         // arrange
-        const string mapboxfile = "mapbox.vector.tile.tests.testdata.lots-of-tags.vector.pbf";
-        var pbfStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(mapboxfile);
+        const string mapboxfile = "lots-of-tags.vector.pbf";
+        var pbfStream = File.OpenRead(Path.Combine("testdata", mapboxfile));
 
         // act
         var layerInfos = VectorTileParser.Parse(pbfStream);

--- a/tests/TileParserTests.cs
+++ b/tests/TileParserTests.cs
@@ -1,12 +1,11 @@
-﻿using System;
+﻿using NUnit.Framework;
+using System;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using NUnit.Framework;
-using static Mapbox.Vector.Tile.Tile;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using static Mapbox.Vector.Tile.Tile;
 
 namespace Mapbox.Vector.Tile.tests;
 
@@ -18,10 +17,10 @@ public class TileParserTests
     public void TestIssue10MapBoxVectorTile()
     {
         // arrange
-        const string mapboxissue10File = "mapbox.vector.tile.tests.testdata.cadastral.pbf";
+        const string mapboxissue10File = "cadastral.pbf";
 
         // act
-        var pbfStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(mapboxissue10File);
+        var pbfStream = File.OpenRead(Path.Combine("testdata", mapboxissue10File));
         var layerInfos = VectorTileParser.Parse(pbfStream);
 
         // asserts
@@ -36,10 +35,10 @@ public class TileParserTests
     public void TestIssue3MapBoxVectorTile()
     {
         // arrange
-        const string mapboxissue3File = "mapbox.vector.tile.tests.testdata.issue3_2911.vector.pbf";
+        const string mapboxissue3File = "issue3_2911.vector.pbf";
 
         // act
-        var pbfStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(mapboxissue3File);
+        var pbfStream = File.OpenRead(Path.Combine("testdata", mapboxissue3File));
         var layerInfos = VectorTileParser.Parse(pbfStream);
 
         // asserts
@@ -64,10 +63,10 @@ public class TileParserTests
     public void TestBagVectorTile()
     {
         // arrange
-        const string bagfile = "mapbox.vector.tile.tests.testdata.bag-17-67317-43082.pbf";
+        const string bagfile = "bag-17-67317-43082.pbf";
 
         // act
-        var pbfStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(bagfile);
+        var pbfStream = File.OpenRead(Path.Combine("testdata", bagfile));
         var layerInfos = VectorTileParser.Parse(pbfStream);
 
         // assert
@@ -105,10 +104,10 @@ public class TileParserTests
     public void TestMapzenTile()
     {
         // arrange
-        const string mapzenfile = "mapbox.vector.tile.tests.testdata.mapzen000.mvt";
+        const string mapzenfile = "mapzen000.mvt";
 
         // act
-        var pbfStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(mapzenfile);
+        var pbfStream = File.OpenRead(Path.Combine("testdata", mapzenfile));
         var layerInfos = VectorTileParser.Parse(pbfStream);
 
         // assert
@@ -125,10 +124,10 @@ public class TileParserTests
     public void TestMapBoxVectorTileNew()
     {
         // arrange
-        const string mapboxfile = "mapbox.vector.tile.tests.testdata.14-8801-5371.vector.pbf";
+        const string mapboxfile = "14-8801-5371.vector.pbf";
 
         // act
-        var pbfStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(mapboxfile);
+        var pbfStream = File.OpenRead(Path.Combine("testdata", mapboxfile));
         var layerInfos = VectorTileParser.Parse(pbfStream);
 
         // check features

--- a/tests/mapbox.vector.tile.tests.csproj
+++ b/tests/mapbox.vector.tile.tests.csproj
@@ -2,26 +2,10 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="testdata\14-8801-5371.vector.pbf" />
-    <EmbeddedResource Include="testdata\issue3_2911.vector.pbf" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="testdata\bag-17-67317-43082.pbf" />
-    <EmbeddedResource Include="testdata\mapzen000.mvt" />
-    <EmbeddedResource Include="testdata\multi-point.pbf" />
-    <EmbeddedResource Include="testdata\multi-line.pbf" />
-    <EmbeddedResource Include="testdata\multi-polygon.pbf" />
-    <EmbeddedResource Include="testdata\polygon-with-inner.pbf" />
-    <EmbeddedResource Include="testdata\singleton-line.pbf" />
-    <EmbeddedResource Include="testdata\singleton-point.pbf" />
-    <EmbeddedResource Include="testdata\singleton-polygon.pbf" />
-    <EmbeddedResource Include="testdata\stacked-multipolygon.pbf" />
-    <EmbeddedResource Include="testdata\lots-of-tags.vector.pbf" />
-    <EmbeddedResource Include="testdata\bag_7_65_41.pbf" />
-    <EmbeddedResource Include="testdata\cadastral.pbf" />
-    <EmbeddedResource Include="testdata\16_34440_23455_raw.mvt" />
+    <Content Include="testdata\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.3.2" />


### PR DESCRIPTION
As suggested by @pauldendulk, this PR enables nullability warnings across the entire solution, and fixes all those which were reported.

The only functional change is that if a layer for some reason has no name, the string "[Unnamed]" is used. According to the Protobuf spec this should never happen, but this can't be guaranteed at compile time.