### PR TITLE
#32 Added license file and SPDX identifier to the Nuget package

### DIFF
--- a/src/mapbox.vector.tile.csproj
+++ b/src/mapbox.vector.tile.csproj
@@ -10,12 +10,17 @@
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>mapbox-vector-tile</PackageId>
     <Authors>Bert Temme</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company />
     <Product />
     <PackageReleaseNotes />
     <Description>.NET library for encoding/decoding Mapbox Vector tiles</Description>
     <RepositoryUrl>https://github.com/bertt/mapbox-vector-tile-cs</RepositoryUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE" Pack="true" PackagePath = "\" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="Properties\**" />

--- a/src/mapbox.vector.tile.csproj
+++ b/src/mapbox.vector.tile.csproj
@@ -18,6 +18,10 @@
     <RepositoryUrl>https://github.com/bertt/mapbox-vector-tile-cs</RepositoryUrl>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\LICENSE" Pack="true" PackagePath = "\" />
   </ItemGroup>

--- a/src/mapbox.vector.tile.csproj
+++ b/src/mapbox.vector.tile.csproj
@@ -18,10 +18,6 @@
     <RepositoryUrl>https://github.com/bertt/mapbox-vector-tile-cs</RepositoryUrl>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Include="..\LICENSE" Pack="true" PackagePath = "\" />
   </ItemGroup>


### PR DESCRIPTION
Suggested fix for #32

I guess the changes are trivial enough that they do not even theoretically warrant a copyright; otherwise feel free to modify the code as you see fit.